### PR TITLE
hotfix: Remove alpine-edge temporarily.

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -32,7 +32,6 @@ jobs:
           - alpine-latest
           - alpine-3.15.0
           - alpine-3.10
-          - alpine-edge
           - debian-11.1
           - debian-10.1
           - debian-10.2
@@ -50,8 +49,6 @@ jobs:
             platforms: linux/386, linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64/v8, linux/ppc64le, linux/s390x
           - distro: alpine-3.10
             platforms: linux/386, linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64/v8, linux/ppc64le, linux/s390x
-          - distro: alpine-edge
-            platforms: linux/386, linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64/v8, linux/ppc64le, linux/riscv64, linux/s390x
           - distro: debian-10.1
             platforms: linux/386, linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64/v8, linux/ppc64le, linux/s390x
             screen: broadway


### PR DESCRIPTION
Removed temporary: linux/arm64/v8, linux/ppc64le, linux/s390.
This commit should be reverted.

Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>
